### PR TITLE
Language/Unlambda.hs: fix file encoding to UTF-8

### DIFF
--- a/Language/Unlambda.hs
+++ b/Language/Unlambda.hs
@@ -5,7 +5,7 @@ Uses pattern guards
 This is an interpreter of the Unlambda language, written in
 the pure, lazy, functional language Haskell.
 
-Copyright (C) 2001 by Ørjan Johansen <oerjan@nvg.ntnu.no>
+Copyright (C) 2001 by Ã˜rjan Johansen <oerjan@nvg.ntnu.no>
 Copyright (C) 2006 by Don Stewart - http://www.cse.unsw.edu.au/~dons
 
 This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
HsColour (setup haddock --hyperlink-source) fails
to process ISO-8859-1 file as:

```
Preprocessing library unlambda-0.1.4...
HsColour: Language/Unlambda.hs: hGetContents: invalid argument (invalid byte sequence)
```

Sonverted to UTF-8

Signed-off-by: Sergei Trofimovich siarheit@google.com
