### PR TITLE
Require cabal-version 1.8

### DIFF
--- a/unlambda.cabal
+++ b/unlambda.cabal
@@ -13,7 +13,7 @@ description:         This is an interpreter of the Unlambda language,
                      written in the pure, lazy, functional language Haskell.
 
 build-type:          Simple
-cabal-version:       >= 1.6
+cabal-version:       >= 1.8
 tested-with:         GHC==8.0.1
 
 source-repository head


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: unlambda.cabal:30:34: version operators used. To use version
operators the package needs to specify at least 'cabal-version: >= 1.8'.
```